### PR TITLE
ci: don't push to (Test)PyPI on (pre)release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,14 +67,14 @@ jobs:
           nox --force-color --python="3.9" --session docs
 
       - name: Publish package on PyPI
-        if: steps.check-version.outputs.tag
+        if: "steps.check-version.outputs.tag && false"
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__
           password: "${{ secrets.PYPI_TOKEN }}"
 
       - name: Publish package on TestPyPI
-        if: "! steps.check-version.outputs.tag"
+        if: "! steps.check-version.outputs.tag && false"
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__


### PR DESCRIPTION
We don't have a PyPI package entry for this project, and no credentials
set up in the CI environment, so these stages shouldn't run.

Keeping them around (but disabled) so we can re-enable them easily
later.