### PR TITLE
Docs fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ import changelog_binder
 
 project = "changelog_binder"
 author = "Scality"
-copyright = f"{datetime.now().year}, Scality"  # noqa: A001
+copyright = f"{datetime.now().year}, {author}"  # noqa: A001
 
 version = changelog_binder.__version__
 release = version

--- a/src/changelog_binder/__init__.py
+++ b/src/changelog_binder/__init__.py
@@ -19,10 +19,12 @@ else:
 __metadata__ = cast(Callable[[str], Distribution], distribution)(__name__).metadata
 __license__ = __metadata__["License"]
 """Package license identifier.
+
 .. versionadded:: 0.0.1
 """
 __version__ = __metadata__["Version"]
 """Package version identifier.
+
 .. versionadded:: 0.0.1
 """
 del __metadata__


### PR DESCRIPTION
A missing newline in a docstring caused Sphinx rendering to be 'incorrect'. Fixing this.