### PR TITLE
ci: disable CodeQL analysis on Dependabot-initiated merges

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,15 @@ name: "CodeQL"
 jobs:
   analyze:
     name: Analyze
+
+    # Publishing analysis results requires write access, which is not
+    # permitted for merges performed by `dependabot[bot]`. This causes
+    # this action to fail (when someone e.g., uses `@dependabot merge`)
+    # which is undesirable.
+    # CodeQL ran on the Dependabot PR anyway, so the branch is somewhat
+    # unlikely to break.
+    if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.actor != 'dependabot[bot]') }}
+
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
The CodeQL CI stage is failing ("by design") for pushes to the `master` branch when the pushed commit originates from @dependabot. This change *should* fix this by not running the stage in said case (we do run it as part of testing the PR created by @dependabot).

However, I can't test this unless this is merged *sigh*

See: https://github.com/scality/changelog-binder/runs/2782047910?check_suite_focus=true#step:3:53
See: https://github.com/nihaals/a-level-misc-solvers/blob/e0473455732d97b884dec3378cf6659e361146b0/.github/workflows/static-analysis.yml#L47-L58