### PR TITLE
docs: project name is `changelog-binder`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import changelog_binder
 
-project = "changelog_binder"
+project = "changelog-binder"
 author = "Scality"
 copyright = f"{datetime.now().year}, {author}"  # noqa: A001
 

--- a/src/changelog_binder/__init__.py
+++ b/src/changelog_binder/__init__.py
@@ -1,4 +1,4 @@
-"""changelog_binder: generate changelogs and release notes from VCS.
+"""changelog-binder: generate changelogs and release notes from VCS.
 
 Tooling to generate changelogs and release notes from snippets stored in a
 project Git_ repository, compatible with the GitWaterFlow_ branching model.


### PR DESCRIPTION
Not `changelog_binder`, which is merely the top-level Python package
name.