### PR TITLE
chore: introduce Python 3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2.2.2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Upgrade pip
         run: |
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build docs
         run: |
-          nox --force-color --python="3.9" --session docs
+          nox --force-color --python="3.10" --session docs
 
       - name: Publish package on PyPI
         if: "steps.check-version.outputs.tag && false"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,19 +20,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { python-version: 3.9, session: "flake8" }
-          - { python-version: 3.9, session: "safety" }
-          - { python-version: 3.9, session: "mypy" }
-          - { python-version: 3.8, session: "mypy" }
-          - { python-version: 3.7, session: "mypy" }
-          - { python-version: 3.6, session: "mypy" }
-          - { python-version: 3.9, session: "tests" }
-          - { python-version: 3.8, session: "tests" }
-          - { python-version: 3.7, session: "tests" }
-          - { python-version: 3.6, session: "tests" }
-          - { python-version: 3.9, session: "typeguard" }
-          - { python-version: 3.9, session: "xdoctest" }
-          - { python-version: 3.9, session: "docs" }
+          - { python-version: "3.10", session: "flake8" }
+          - { python-version: "3.10", session: "safety" }
+          - { python-version: "3.10", session: "mypy" }
+          - { python-version: "3.9", session: "mypy" }
+          - { python-version: "3.8", session: "mypy" }
+          - { python-version: "3.7", session: "mypy" }
+          - { python-version: "3.6", session: "mypy" }
+          - { python-version: "3.10", session: "tests" }
+          - { python-version: "3.9", session: "tests" }
+          - { python-version: "3.8", session: "tests" }
+          - { python-version: "3.7", session: "tests" }
+          - { python-version: "3.6", session: "tests" }
+          - { python-version: "3.10", session: "typeguard" }
+          - { python-version: "3.10", session: "xdoctest" }
+          - { python-version: "3.10", session: "docs" }
 
     env:
       NOXSESSION: "${{ matrix.session }}"
@@ -86,10 +88,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v2.3.4
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2.2.2
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Upgrade pip
         run: |

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,6 +18,7 @@ PYTHON_VERSIONS = [
     "3.7",
     "3.8",
     "3.9",
+    "3.10",
 ]
 
 SOURCES = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :; Python :: 3.10",
     "Topic :: Documentation",
     "Topic :: Documentation :: Sphinx",
     "Topic :: Software Development",


### PR DESCRIPTION
Now 3.10 is out, add it to the test matrix, and move jobs using the
"latest" version from 3.9 to 3.10 instead.