### PR TITLE
chore: simplify `mypy` configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,22 +100,8 @@ show_missing = true
 fail_under = 100
 
 [tool.mypy]
-check_untyped_defs = true
-disallow_any_generics = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-no_implicit_optional = true
-no_implicit_reexport = true
+strict = true
 pretty = true
 show_column_numbers = true
 show_error_codes = true
 show_error_context = true
-strict_equality = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_unreachable = true
-warn_unused_configs = true
-warn_unused_ignores = true


### PR DESCRIPTION
Instead of enabling a bunch of 'more strict' warnings one-by-one, tell
`mypy` to be strict, end of story.

See: https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict