### PR TITLE
ci: add `tests-success` meta-job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,3 +117,18 @@ jobs:
           nox --force-color --session=coverage -- xml
       - name: Upload coverage report
         uses: codecov/codecov-action@v2.1.0
+
+  tests-success:
+    runs-on: ubuntu-latest
+    needs:
+      - tests
+      - coverage
+    steps:
+      - name: Ensure tests succeeded
+        if: "${{ needs.tests.result != 'success' }}"
+        run: |
+          exit 1
+      - name: Ensure coverage succeeded
+        if: "${{ needs.coverage.result != 'success' }}"
+        run: |
+          exit 1


### PR DESCRIPTION
When using GitHub branch protections, listing all jobs that must succeed
is a bit of a hassle, especially when those jobs change (e.g., when the
Python version that's used by default changes).

Instead, add a 'meta-job' which ensures all required jobs passes, and
fails otherwise. Using this approach, only a single check must be
configured in branch protections.

See: https://github.com/scality/changelog-binder/pull/96#issuecomment-943773434
See: https://github.com/neos/neos-development-collection/pull/3291
See: https://github.community/t/status-check-for-a-matrix-jobs/127354/7